### PR TITLE
Constraint RGB [0, 255]

### DIFF
--- a/R/anomalize.R
+++ b/R/anomalize.R
@@ -106,6 +106,12 @@ anomalize <- function(x, mode = c("deuteranopia", "protanopia", "tritanopia",
   # Conversion
   RGB2 <- solve(RGB_to_LMS) %*% S %*% RGB_to_LMS %*% RGB1
 
+  # RGB constraints
+  for (j in 1:ncol(RGB2)) {
+      RGB2[, j] <- pmin(RGB2[, j], rep(255, 3))
+      RGB2[, j] <- pmax(RGB2[, j], rep(0, 3))
+  }
+
   # Convert to Hex colour code
   grDevices::rgb(red = RGB2[1, ], green = RGB2[2, ], blue = RGB2[3, ],
                  names = names(x), maxColorValue = 255)


### PR DESCRIPTION
The `anomalize` function sometimes produces RGB values outside the allowed range of [0, 255]. This raises an error with `grDevices`:

``` r
khroma:::anomalize("#9C964A", mode = 'tritanopia')
#> [1] "#A58C8C"

khroma:::anomalize("#FAD77B", mode = 'tritanopia')
#> Error in grDevices::rgb(red = RGB2[1, ], green = RGB2[2, ], blue = RGB2[3, : color intensity 261, not in 0:255
```

<sup>Created on 2020-07-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

My solution is a bit of a hack, but it's simply to restrict the RGB values using `pmin`, `pmax`.