### PR TITLE
Fix test broken by testthat 3.1.2

### DIFF
--- a/tests/testthat/test-colour.R
+++ b/tests/testthat/test-colour.R
@@ -124,15 +124,12 @@ test_that("Colour-blind attributes", {
 })
 test_that("Print with crayon", {
   skip_if_not_installed("crayon")
-  options(crayon.enabled = FALSE)
 
   palette <- colour("okabe ito")
-
   col <- utils::capture.output(print(palette(8)))
   expect_type(col, "character")
 
-  skip_if_not_installed("crayon")
-  options(crayon.enabled = TRUE)
+  local_reproducible_output(crayon = TRUE)
   col <- utils::capture.output(print(palette(8)))
   expect_true(crayon::has_style(col))
 })


### PR DESCRIPTION
`test_that()` automatically runs `local_reproducible_output()` and the default now also sets `cli.num_colors` which causes your test to fail. The easiest way to fix the problem is to rely on `local_reproducible_output()` to turn crayon back on.

I'll be submitting testthat to CRAN next week (Jan 21), so if you have time I'd really appreciate a CRAN release.